### PR TITLE
Set fresh `refresh_token` in `sessionStorage` after RefreshTokenGrant

### DIFF
--- a/src/RefreshTokenGrant.ts
+++ b/src/RefreshTokenGrant.ts
@@ -70,6 +70,9 @@ const renewTokens = async () => {
     );
   }
 
+  // set new refresh token for token rotation
+  sessionStorage.setItem("refresh_token",token_response["refresh_token"]);
+
   return {
     ...token_response,
     dpop_key_pair: key_pair,


### PR DESCRIPTION
Set new `refresh_token` in `sessionStorage` for token rotation after RefreshTokenGrant.
Thanks to @jg10-mastodon-social for pointing this out in their [comment](https://github.com/uvdsl/solid-oidc-client-browser/issues/3#issuecomment-2834559369).