### PR TITLE
Addressing #6 - public client: `token_endpoint_auth_method` should be `none` (RefreshTokenGrant)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ npm install @uvdsl/solid-oidc-client-browser
 #### via a CDN provider
 For the minified version...
 ```html
-<script type="module" src="https://unpkg.com/@uvdsl/solid-oidc-client-browser@0.0.8/dist/esm/index.min.js"></script>
+<script type="module" src="https://unpkg.com/@uvdsl/solid-oidc-client-browser@0.0.9/dist/esm/index.min.js"></script>
 ```
 
 And the regular version...
 ```html
-<script type="module" src="https://unpkg.com/@uvdsl/solid-oidc-client-browser@0.0.8/dist/esm/index.js"></script>
+<script type="module" src="https://unpkg.com/@uvdsl/solid-oidc-client-browser@0.0.9/dist/esm/index.js"></script>
 ```
 Do not forget to adjust the version to the one you want! The latest version is displayed at the top of the README in the `npm` badge.
 
@@ -49,7 +49,7 @@ You can use this library along the lines of these examples:
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Solid Login Page</title>
-    <script type="module" src="https://unpkg.com/@uvdsl/solid-oidc-client-browser@0.0.8/dist/esm/index.min.js"></script>
+    <script type="module" src="https://unpkg.com/@uvdsl/solid-oidc-client-browser@0.0.9/dist/esm/index.min.js"></script>
 </head>
 
 <body>
@@ -70,7 +70,7 @@ You can use this library along the lines of these examples:
 
         document.addEventListener('DOMContentLoaded', async () => {
             // Import the Session class from the library
-            const module = await import('https://unpkg.com/@uvdsl/solid-oidc-client-browser@0.0.8/dist/esm/index.min.js');
+            const module = await import('https://unpkg.com/@uvdsl/solid-oidc-client-browser@0.0.9/dist/esm/index.min.js');
             const Session = module.Session;
 
             // Create a new session

--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@ This library implements a very simple version of the Solid OIDC protocol:
 - [x] AuthorizationCodeGrant
 - [x] with PKCE (RFC 7636)
 - [x] with `iss` check (RFC 9207)
+- [ ] TODO: with provided `client_id` (dereferencable to client profile document)
 - [x] with dynamic client registration 
-- [ ] TODO: support provided `client_id` with client profile document
-- [x] RefreshTokenGrant to renew a session
-- [x] Uses `sessionStorage` to temporarily store session information like `idp`, `client_id`, `refresh_token`, and `token_endpoint`. The storage is origin-bound and tab-bound, meaning that you can have multiple distinct sessions on the same origin using different tabs (see also [security considerations](#security-considerations)).
+- [x] RefreshTokenGrant to renew tokens and to restore a session
+
+Good to know (see also the [security considerations](#security-considerations)):
+- [x] Uses [sessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) in the AuthorizationCodeGrant to temporarily store session information like `idp`, `client_id`, `pkce_code_verifier`, and `csrf_token`. The storage is origin-bound and tab-bound. 
+- [x] Uses the [IndexedDB API](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) to store session information like `idp`, `client_id`, `refesh_token`, and the (non-extractable) DPoP KeyPair which was used in the AuthorizationCodeGrant. These are later re-used in the RefreshTokenGrant to renew the tokens or to restore a session.
 
 ## Installation
 You can use this library in your project. Let me know how you get on with it! :rocket:
@@ -179,16 +182,26 @@ You can use the `session` object in that store to let the store fetch (authentic
 
 ## Security Considerations
 
-For a discussion around security considerations for this library see also [#3](https://github.com/uvdsl/solid-oidc-client-browser/issues/3). We provide a digest here:
+For a discussion around security considerations for this library see also the issues: [#3](https://github.com/uvdsl/solid-oidc-client-browser/issues/3) and [#6](https://github.com/uvdsl/solid-oidc-client-browser/issues/6). We provide a digest here:
 
-#### Status Quo: `sessionStorage`
+#### Status Quo: `IndexedDB API`
 
-We chose to not use `localStorage` because we did not want to persist the refresh tokens - I ([@uvdsl](https://github.com/uvdsl/)) am unsure if this is really secure. So, we chose to use `sessionStorage`. Yes, if a user closes a tab, they need to login again - but I like that better than potentially leaking a session across tabs or being extracted from `localStorage` after the fact. Again - not sure if this concern is valid - but I feel better this way 😄 
+We chose an `IndexedDB` over `localStorage` or `sessionStorage` because:
+To renew tokens, the token request (in a RefreshTokenGrant) must contain a DPoP token signed by the same DPoP private key that was used on the initial token request (in the initial AuthorizationCodeGrant) for the session.
+To persist this private key, we would need to make it extractable.
+This means that if an attacker gains access to `localStorage` or `sessionStorage`, they are able to take the `refresh_token` and the private key, and re-use both outside of the context of the compromised application.
 
-We use `sessionStorage` to store `client_id`, `refresh token` etc. to allow for refreshing tokens using the RefreshTokenFlow. No redirect is needed in that flow, so if a `client_id`, `refresh token` etc. are present in the `sessionStorage`, we simply obtain a fresh set of tokens. Everytime the page is reloaded, the RefreshTokenGrant is executed (as the `sessionStorage` persists until the tab is closed).
+We use an `IndexedDB` which allows us to store the non-extractable DPoP KeyPair. This keypair cannot be extracted from the Browser's security context.
+This means that, if an attacker gains access to our IndexedDB, they can obtain a fresh set of tokens and thus have successfully established a valid user session (using the DPoP keypair from the `IndexedDB`). 
+But they do not fully control the DPoP KeyPair. They cannot extract the DPoP KeyPair and send it away. They can only operate within the compromised application.
 
-`sessionStorage` is origin-bound and tab-bound, meaning that you can have multiple distinct sessions on the same origin using different tabs. 
+#### Why not rely on "Silent Authentication"?
 
+Currently, CSS/Pivot and ESS (afaik) set session cookies with `SameSite=None`
+- which in turn allows silent authentication via iframes and popups 
+- which in turn allows an attacker upon successful JS execution in a compromised application to execute silent authentication in the background without interuption
+- which in turn results in a set of tokens bound to an attacker controlled and thus certainly extractable DPoP keypair
+- which in turn allows the attacker to re-use the session outside of the compromised application.
 
 #### Hosting multiple Solid Apps on the same origin (at different paths)
 
@@ -211,7 +224,10 @@ If you think that the two Solid Apps should still have distinct `client_id`, the
 To summarise the point: The question on multiple apps on the same origin is to be answered by considering the conceptual relation of the multiple apps with regards to the browers' security mechansims. 
 
 
-We - as in this library - cannot manage distinct sessions within one `sessionStorage` securely. Not because we do not want to but because the browser does not provide us a more granular and secure option. Do you really want distinct logins and distinct sessions? This is not a question of concept but a question of security. You MUST deploy the apps on different origins.
+We - as in this library - cannot manage distinct sessions via the `IndexedDB API` securely. Not because we do not want to but because the browser does not provide us a more granular and secure (!) option. Of course, we could provide different databases for different paths on an origin.
+But all these databases would still be accessible from any path on the origin.
+
+Do you really want distinct logins and distinct sessions? This is not a question of concept but a question of security. You MUST deploy the apps on different origins.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can use this library along the lines of these examples:
             // Set up the login button
             document.getElementById('loginButton').addEventListener('click', () => {
                 // Use a default IDP or let user specify one
-                const idp = "https://solidcommunity.net"; // Default IDP - you can change this
+                const idp = "https://solidcommunity.net/"; // Default IDP - you can change this
                 const redirect_uri = window.location.href;
 
                 // Redirect to login

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@uvdsl/solid-oidc-client-browser",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@uvdsl/solid-oidc-client-browser",
-            "version": "0.0.8",
+            "version": "0.0.9",
             "license": "MIT",
             "dependencies": {
                 "jose": "^5.9.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uvdsl/solid-oidc-client-browser",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "homepage": "https://github.com/uvdsl/",
     "author": "uvdsl - Christoph Braun",
     "license": "MIT",

--- a/src/RefreshTokenGrant.ts
+++ b/src/RefreshTokenGrant.ts
@@ -16,7 +16,7 @@ const renewTokens = async () => {
   const client_id = await sessionDatabase.getItem("client_id") as string;
   const token_endpoint = await sessionDatabase.getItem("token_endpoint") as string;
   const key_pair = await sessionDatabase.getItem("dpop_keypair") as GenerateKeyPairResult<KeyLike>;
-  const refresh_token = await sessionDatabase.getItem("refresh_token");
+  const refresh_token = await sessionDatabase.getItem("refresh_token") as string;
 
   if (client_id === null || token_endpoint === null || key_pair === null || refresh_token === null) {
     // we can not restore the old session

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -5,6 +5,7 @@ import {
 } from "./AuthorizationCodeGrantFlow";
 import { SessionTokenInformation } from "./SessionTokenInformation";
 import { renewTokens } from "./RefreshTokenGrant";
+import { SessionDatabase } from "./SessionDatabase";
 
 export class Session {
   private tokenInformation: SessionTokenInformation | undefined;
@@ -13,16 +14,14 @@ export class Session {
 
   login = redirectForLogin;
 
-  logout() {
+  async logout() {
     this.tokenInformation = undefined;
     this.isActive_ = false;
     this.webId_ = undefined;
-    // clean session storage
-    sessionStorage.removeItem("idp");
-    sessionStorage.removeItem("client_id");
-    sessionStorage.removeItem("client_secret");
-    sessionStorage.removeItem("token_endpoint");
-    sessionStorage.removeItem("refresh_token");
+    // clean session database
+    const sessionDatabase = await new SessionDatabase().init()
+    await sessionDatabase.clear();
+    sessionDatabase.close();
   }
 
   handleRedirectFromLogin() {

--- a/src/SessionDatabase.ts
+++ b/src/SessionDatabase.ts
@@ -1,0 +1,173 @@
+/**
+ * A simple IndexedDB wrapper
+ */
+export class SessionDatabase {
+    private readonly dbName: string;
+    private readonly storeName: string;
+    private readonly dbVersion: number;
+    private db: IDBDatabase | null = null;
+
+    /**
+     * Creates a new instance
+     * @param dbName The name of the IndexedDB database
+     * @param storeName The name of the object store
+     * @param dbVersion The database version
+     */
+    constructor(dbName: string = 'soidc', storeName: string = 'session', dbVersion: number = 1) {
+        this.dbName = dbName;
+        this.storeName = storeName;
+        this.dbVersion = dbVersion;
+    }
+
+    /**
+     * Initializes the IndexedDB database
+     * @returns Promise that resolves when the database is ready
+     */
+    public async init(): Promise<SessionDatabase> {
+        return new Promise((resolve, reject) => {
+            const request = indexedDB.open(this.dbName, this.dbVersion);
+
+            request.onerror = (event) => {
+                reject(new Error(`Database error: ${(event.target as IDBRequest).error}`));
+            };
+
+            request.onsuccess = (event) => {
+                this.db = (event.target as IDBOpenDBRequest).result;
+                resolve(this);
+            };
+
+            request.onupgradeneeded = (event) => {
+                const db = (event.target as IDBOpenDBRequest).result;
+
+                // Check if the object store already exists, if not create it
+                if (!db.objectStoreNames.contains(this.storeName)) {
+                    db.createObjectStore(this.storeName);
+                }
+            };
+        });
+    }
+
+    /**
+     * Stores any value in the database with the given ID as key
+     * @param id The identifier/key for the value
+     * @param value The value to store
+     */
+    public async setItem(id: string, value: any): Promise<void> {
+        if (!this.db) {
+            await this.init();
+        }
+
+        return new Promise((resolve, reject) => {
+            const transaction = this.db!.transaction(this.storeName, 'readwrite');
+            // Handle transation
+            transaction.oncomplete = () => {
+                resolve();
+            };
+            transaction.onerror = (event) => {
+                reject(new Error(`Transaction error for setItem(${id},...): ${(event.target as IDBTransaction).error}`));
+            };
+
+            transaction.onabort = (event) => {
+                reject(new Error(`Transaction aborted for setItem(${id},...): ${(event.target as IDBTransaction).error}`));
+            };
+            // Perform the request within the transaction
+            const store = transaction.objectStore(this.storeName);
+            store.put(value, id);
+        });
+    }
+
+    /**
+      * Retrieves a value from the database by ID
+      * @param id The identifier/key for the value
+      * @returns The stored value or null if not found
+      */
+    public async getItem(id: string): Promise<any> {
+        if (!this.db) {
+            await this.init();
+        }
+
+        return new Promise((resolve, reject) => {
+            const transaction = this.db!.transaction(this.storeName, 'readonly');
+            // Handle transation
+            transaction.onerror = (event) => {
+                reject(new Error(`Transaction error for getItem(${id}): ${(event.target as IDBTransaction).error}`));
+            };
+
+            transaction.onabort = (event) => {
+                reject(new Error(`Transaction aborted for getItem(${id}): ${(event.target as IDBTransaction).error}`));
+            };
+            // Perform the request within the transaction
+            const store = transaction.objectStore(this.storeName);
+            const request = store.get(id);
+            request.onsuccess = () => {
+                resolve(request.result || null);
+            };
+        });
+    }
+
+    /**
+     * Removes an item from the database
+     * @param id The identifier of the item to remove
+     */
+    public async deleteItem(id: string): Promise<void> {
+        if (!this.db) {
+            await this.init();
+        }
+
+        return new Promise((resolve, reject) => {
+            const transaction = this.db!.transaction(this.storeName, 'readwrite');
+            // Handle transation
+            transaction.oncomplete = () => {
+                resolve();
+            };
+            transaction.onerror = (event) => {
+                reject(new Error(`Transaction error for deleteItem(${id}): ${(event.target as IDBTransaction).error}`));
+            };
+
+            transaction.onabort = (event) => {
+                reject(new Error(`Transaction aborted for deleteItem(${id}): ${(event.target as IDBTransaction).error}`));
+            };
+            // Perform the request within the transaction
+            const store = transaction.objectStore(this.storeName);
+            store.delete(id);
+        });
+    }
+
+    /**
+     * Clears all items from the database
+     */
+    public async clear(): Promise<void> {
+        if (!this.db) {
+            await this.init();
+        }
+
+        return new Promise((resolve, reject) => {
+            const transaction = this.db!.transaction(this.storeName, 'readwrite');
+            // Handle transation
+            transaction.oncomplete = () => {
+                resolve();
+            };
+            transaction.onerror = (event) => {
+                reject(new Error(`Transaction error for clear(): ${(event.target as IDBTransaction).error}`));
+            };
+
+            transaction.onabort = (event) => {
+                reject(new Error(`Transaction aborted for clear(): ${(event.target as IDBTransaction).error}`));
+            };
+            // Perform the request within the transaction
+            const store = transaction.objectStore(this.storeName);
+            store.clear();
+        });
+    }
+
+    /**
+     * Closes the database connection
+     */
+    public close(): void {
+        if (this.db) {
+            this.db.close();
+            this.db = null;
+        }
+    }
+
+}

--- a/src/requestDynamicClientRegistration.ts
+++ b/src/requestDynamicClientRegistration.ts
@@ -14,7 +14,7 @@ const requestDynamicClientRegistration = async (
     redirect_uris: redirect__uris,
     grant_types: ["authorization_code", "refresh_token"],
     id_token_signed_response_alg: "ES256",
-    token_endpoint_auth_method: "client_secret_basic", // also works with value "none" if you do not provide "client_secret" on token request
+    token_endpoint_auth_method: "none",
     application_type: "web",
     subject_type: "public",
   };


### PR DESCRIPTION
This PR competes with #7.

In this version, we rely on the RefreshTokenGrant to  restore a session.
For persistence, we use the [IndexedDB API](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) as discussed [here](https://github.com/uvdsl/solid-oidc-client-browser/issues/6#issuecomment-2848311135).

We do not use Silent Authentication which addresses the [concern](https://github.com/uvdsl/solid-oidc-client-browser/pull/7#issuecomment-2848046144) regarding the IDPs session cookies being `SameSite=None`.

This PR provides a clear improvement in terms of security compared to the current main version.
The current version stores `client_secret` and `refresh_token` in `sessionStorage`, which is equivalent to storing an (extractable) DPoP KeyPair in `sessionStorage`. Because we store a  non-extractable DPoP KeyPair via the IndexedDB API we reduce the risk surface of this library, and follow the [Best Current Practice](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps).