### PR TITLE
s/window.crypto/globalThis.crypto/

### DIFF
--- a/src/core/AuthorizationCodeGrant.ts
+++ b/src/core/AuthorizationCodeGrant.ts
@@ -74,7 +74,7 @@ const redirectForLogin = async (idp: string, redirect_uri: string, client_detail
   sessionStorage.setItem("pkce_code_verifier", pkce_code_verifier);
 
   // RFC 6749 OAuth 2.0 - CSRF token
-  const csrf_token = window.crypto.randomUUID();
+  const csrf_token = globalThis.crypto.randomUUID();
   sessionStorage.setItem("csrf_token", csrf_token);
 
   // redirect to idp
@@ -99,10 +99,10 @@ const redirectForLogin = async (idp: string, redirect_uri: string, client_detail
 const getPKCEcode = async () => {
   // create random string as PKCE code verifier
   const pkce_code_verifier =
-    window.crypto.randomUUID() + "-" + window.crypto.randomUUID();
+    globalThis.crypto.randomUUID() + "-" + globalThis.crypto.randomUUID();
   // hash the verifier and base64URL encode as PKCE code challenge
   const digest = new Uint8Array(
-    await window.crypto.subtle.digest(
+    await globalThis.crypto.subtle.digest(
       "SHA-256",
       new TextEncoder().encode(pkce_code_verifier)
     )
@@ -277,7 +277,7 @@ const requestAccessToken = async (
     htm: "POST",
   })
     .setIssuedAt()
-    .setJti(window.crypto.randomUUID())
+    .setJti(globalThis.crypto.randomUUID())
     .setProtectedHeader({
       alg: "ES256",
       typ: "dpop+jwt",

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -361,7 +361,7 @@ export class SessionCore extends EventTarget implements Session {
     );
     return new SignJWT(payload)
       .setIssuedAt()
-      .setJti(window.crypto.randomUUID())
+      .setJti(globalThis.crypto.randomUUID())
       .setProtectedHeader({
         alg: "ES256",
         typ: "dpop+jwt",

--- a/tests/core/Session.test.ts
+++ b/tests/core/Session.test.ts
@@ -59,7 +59,7 @@ describe('SessionCore', () => {
         (session as any).information = { ...mockSessionInfo };
         (session as any).information.clientDetails.client_id = client_id;
 
-        // 2. Mock the internal _computeAth method, as it depends on `window.crypto`
+        // 2. Mock the internal _computeAth method, as it depends on `globalThis.crypto`
         // which is not available in the JSDOM test environment.
         const computeAthSpy = jest.spyOn(session as any, '_computeAth')
             .mockResolvedValueOnce('mock-ath-value');


### PR DESCRIPTION
Currently I only extend the `SessionCore` class for initial implementation of session which uses self issued tokens in CSS instance that acts as the OP.
I know that you want to focus on a browser but AFAIK there thould be no problem with this change.

Currently I needed to copy & paste `_createSignedDPoPToken` method into my sublcass and `@ts-ignore` bunch of errors about accessing private properties. It still works as an early draft :cat: 